### PR TITLE
Escape backslashes before replacing bindings

### DIFF
--- a/Clockwork/DataSource/EloquentDataSource.php
+++ b/Clockwork/DataSource/EloquentDataSource.php
@@ -119,6 +119,9 @@ class EloquentDataSource extends DataSource
 		foreach ($bindings as $binding) {
 			$binding = $this->databaseManager->connection($connection)->getPdo()->quote($binding);
 
+			# if a binding contains 2 backslashes, escape them before preg_replace
+			$binding = str_replace('\\\\', '\\\\\\', $binding);
+
 			$query = preg_replace('/\?/', $binding, $query, 1);
 		}
 


### PR DESCRIPTION
If a binding contains 2 backslashes, escape them before `preg_replace`, otherwise they get reduced to 1.

When performing queries on polymorphic relationships, the binding value is actually "App\\Model" but after it goes through `preg_replace`, it becomes "App\Model", which, if you try to run the SQL query directly, won't work.